### PR TITLE
Wrap item title H2 element in an anchor tag

### DIFF
--- a/src/Default.aspx
+++ b/src/Default.aspx
@@ -30,8 +30,9 @@
 						<span class="month"><%# Item.PublishDate.ToString("MMM") %></span>
 						<span class="day"><%# Item.PublishDate.Day %></span>
 					</time>
-
-					<h2 itemprop="name"><%# Item.Title.Text %></h2>
+					<a itemprop="url" href="<%#: Item.Links[0].Uri %>">
+						<h2 itemprop="name"><%# Item.Title.Text %></h2>
+					</a>
 					<p itemprop="articleBody"><%# Item.Summary.Text %></p>
 
 					<a itemprop="url" href="<%#: Item.Links[0].Uri %>" title="<%#: Item.Title.Text %>">Read the article</a>


### PR DESCRIPTION
Referencing [FeedCollector Issue 2](https://github.com/madskristensen/FeedCollector/issues/2)

Making the h2 item title clickable by wrapping it in an anchor element. It helps users on mobile devices hit the link target easier.

(Sorry about the line-ending. I edited this file on the GitHub website.)
